### PR TITLE
Fix linum format string width

### DIFF
--- a/hlinum.el
+++ b/hlinum.el
@@ -69,7 +69,7 @@ If LINE is nil, highlight current line."
         (let* ((str (overlay-get ov 'before-string))
                (lstr (overlay-get ov 'linum-str))
                (nov (move-overlay ov pt pt)))
-          (add-text-properties 0 (string-width lstr)
+          (add-text-properties 0 (length lstr)
                                `(face ,face) lstr)
           (add-text-properties 0 1 `(display ((margin left-margin)
                                               ,lstr)) str)


### PR DESCRIPTION
`string-width' returns the wrong value:

    (string-width "\u2502") ;; => 2
    (length       "\u2502") ;; => 1

It causes the following error:

    1 Debugger entered--Lisp error: (args-out-of-range 0 6)
    2   add-text-properties(0 6 (face linum-highlight-face) #("   1│" 0 5 (face linum)))
    3   hlinum-color(linum-highlight-face nil)
    4   hlinum-highlight-line()
    5   apply(hlinum-highlight-line nil)
    6   linum-update-current()