### PR TITLE
Mark region after scroll

### DIFF
--- a/hlinum.el
+++ b/hlinum.el
@@ -91,7 +91,9 @@ If LINE is nil, highlight current line."
 
 (defun hlinum-after-scroll (win start)
   (when (eq (current-buffer) (window-buffer))
-    (hlinum-highlight-line)))
+    (if mark-active
+        (hlinum-highlight-region)
+      (hlinum-highlight-line))))
 
 ;;;###autoload
 (defun hlinum-activate ()


### PR DESCRIPTION
I encountered this while using evil-mode.

If I enter visual state and then scroll (using `C-u` or `C-d`), currently it only highlights one line.

What I'm proposing is, after scrolling, if we have been highlighting regions, keep doing that.